### PR TITLE
Use a virtualenv in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,30 @@
 FROM centos:8
+
+
 RUN mkdir /src && \
     yum install -y dnf-plugins-core && \
-    yum config-manager --set-enabled PowerTools && \
+    yum config-manager --set-enabled powertools && \
     yum install -y python3 git pandoc python3-sphinx java-1.8.0-openjdk graphviz curl libpq-devel gcc python3-devel make && \
-    pip3 install -U --no-cache poetry setuptools pipenv && \
-    curl -o /src/plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.jar/download && \
+    yum clean all
+
+RUN python3 -m venv /opt/aletheia_venv
+
+ENV PATH="/opt/aletheia_venv/bin:$PATH" \
+    HOME="/src/aletheia"
+
+RUN curl -o /src/plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.jar/download && \
     printf '#!/bin/sh\nexec java -jar /src/plantuml.jar "$@"' > /usr/bin/plantuml && \
     chmod +x /usr/bin/plantuml && \
-    yum clean all && \
     mkdir -p /etc/aletheia && \
     git config --system credential.helper 'store --file /etc/aletheia/git-credentials' && \
     git config --system user.email "aletheia@redhat.com" && \
     git config --system user.name "Aletheia Docs Builder"
+
+ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=off PIPENV_VENV_IN_PROJECT=1
+RUN /opt/aletheia_venv/bin/pip install -U --no-cache pip setuptools poetry pipenv
 COPY poetry.lock pyproject.toml /src/aletheia/
 WORKDIR /src/aletheia
-ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=off PIPENV_VENV_IN_PROJECT=1
-RUN poetry config virtualenvs.create false && poetry install
-COPY . /src/aletheia/
-RUN python3 setup.py install
+RUN source /opt/aletheia_venv/bin/activate && poetry install
+COPY . /src/aletheia
+RUN pip install --no-deps .  # deps already installed via poetry
 CMD ["aletheia"]


### PR DESCRIPTION
I was unable to build this Dockerfile due to package conflicts related to distutils [like this](https://stackoverflow.com/questions/53807511/pip-cannot-uninstall-package-it-is-a-distutils-installed-project) -- switching to install inside a virtual env instead of doing a global "pip install" in the centos image gets things working.

I also switched to `pip install .` instead of `python setup.py install` because I was hitting an error with a relative import:
```
  File "/opt/aletheia_venv/lib64/python3.6/site-packages/aletheia-0.1-py3.6.egg/aletheia/__main__.py", line 9, in <module>
    from . import DEFAULTS, command
  File "/opt/aletheia_venv/lib64/python3.6/site-packages/aletheia-0.1-py3.6.egg/aletheia/command.py", line 9, in <module>
    from . import DEFAULTS, exceptions, pipeline
  File "/opt/aletheia_venv/lib64/python3.6/site-packages/aletheia-0.1-py3.6.egg/aletheia/pipeline.py", line 13, in <module>
    from .builders import sphinx, plantuml
ImportError: cannot import name 'sphinx'
```